### PR TITLE
fix(popover-content): add missing className merge

### DIFF
--- a/packages/popover/src/popover.tsx
+++ b/packages/popover/src/popover.tsx
@@ -134,7 +134,7 @@ export const PopoverContent = forwardRef<PopoverContentProps, "section">(
         <Motion
           {...popoverProps}
           onUpdate={onTransitionEnd}
-          className={cx("chakra-popover__content")}
+          className={cx("chakra-popover__content", props.className)}
           __css={contentStyles}
           variants={motionVariants}
           initial={false}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfils the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The `PopoverContent` component accepts the `className` prop but doesn't apply it to the underlying component.

## What is the new behavior?

The `PopoverContent` component now apply the `className` prop to the underlying component.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Thank you for your work on chakra-ui! 🙏